### PR TITLE
exe: Rename `vertex-claude` to claude

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
           };
           
           vertex-claude = pkgs.writeShellApplication {
-            name = "vertex-claude";
+            name = "claude";
             runtimeInputs = with pkgs; [ google-cloud-sdk claude-code select-gcloud-project ];
             text = ''
               set -euo pipefail


### PR DESCRIPTION
So it can be used with home-manager's claude-code module