### PR TITLE
Upgrade to Claude Sonnet 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vertex
 
-One-click AI agent setup through Google Vertex AI Platform. Currently, this launches **Claude Code** using your Google login[^cc] configured to use the **Claude Sonnet 4** model.
+One-click AI agent setup through Google Vertex AI Platform. Currently, this launches **Claude Code** using your Google login[^cc] configured to use the **Claude Sonnet 4.5** model.
 
 [^cc]: See [Claude Code on Google Vertex AI](https://docs.anthropic.com/en/docs/claude-code/google-vertex-ai)
 
@@ -87,4 +87,4 @@ nix run github:juspay/vertex -- --dangerously-skip-permissions
 
 ## Goals
 
-Combine `google-cloud-sdk`, `gemini-cli`, `claude-code` (from nixpkgs) to provide a seamless entrypoint to getting AI agents working using Claude 4 Sonnet through Google Vertex AI platform (provided by your organization).
+Combine `google-cloud-sdk`, `gemini-cli`, `claude-code` (from nixpkgs) to provide a seamless entrypoint to getting AI agents working using Claude Sonnet 4.5 through Google Vertex AI platform (provided by your organization).

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         let
           # Configuration - Update these values for your setup
           vertexRegion = "us-east5";
-          modelName = "claude-sonnet-4";
+          modelName = "claude-sonnet-4-5";
           smallModelName = "claude-3-5-haiku";
           
           select-gcloud-project = pkgs.writeShellApplication {


### PR DESCRIPTION
## Summary
- Upgrades the default model from Claude Sonnet 4 to Claude Sonnet 4.5
- Updates documentation to reflect the new model version

## Important Note
Users may need to run the following command when using the new version with Sonnet 4.5:
```bash
gcloud config set project dev-ai-gamma
```

## Changes
- Updated model name from `claude-sonnet-4` to `claude-sonnet-4-5` in flake.nix
- Updated README.md to reference Claude Sonnet 4.5