### PR TITLE
Upgrade nixpkgs for Claude Code 2.0 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759226052,
-        "narHash": "sha256-ddDtY8iOLBMQ0AwH9wxuboORYV4Z1B3dC5FWIHfqjBA=",
+        "lastModified": 1759733170,
+        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17aa85c27e8a700de4f3645e0afce383ceabcdf2",
+        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "17aa85c",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759226052,
+        "narHash": "sha256-ddDtY8iOLBMQ0AwH9wxuboORYV4Z1B3dC5FWIHfqjBA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "17aa85c27e8a700de4f3645e0afce383ceabcdf2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "17aa85c",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,7 @@
 
   inputs = {
     # Temporarily pinned to specific commit
-    # TODO: Revert to nixos-unstable after https://github.com/NixOS/nixpkgs/pull/447431 is propagated to mainline cache
-    nixpkgs.url = "github:NixOS/nixpkgs/17aa85c";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
   };
 
   inputs = {
-    # Temporarily pinned to specific commit
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,9 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Temporarily pinned to specific commit
+    # TODO: Revert to nixos-unstable after https://github.com/NixOS/nixpkgs/pull/447431 is propagated to mainline cache
+    nixpkgs.url = "github:NixOS/nixpkgs/17aa85c";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 


### PR DESCRIPTION
## Summary

Temporarily pins nixpkgs to commit 17aa85c to get Claude Code 2.0 support while waiting for https://github.com/NixOS/nixpkgs/pull/447431 to propagate to the mainline cache.

## Testing

Users can test this branch directly:

```bash
nix run github:juspay/vertex/claude2
```

Closes #11